### PR TITLE
Fix scoring bug in findBestMove

### DIFF
--- a/src/Engine/Moves.hs
+++ b/src/Engine/Moves.hs
@@ -7,29 +7,31 @@ module Engine.Moves
   ) where
 
 import Data.List
+import Data.Maybe
 import Engine.Board
 
 type Move = (Int, Int)
 type Score = Int
 type Depth = Int
-data Color = Engine | Player deriving (Eq)
+data Color = Engine | Player deriving (Eq, Show)
 
 findBestMove :: Color -> Depth -> Board -> (Move, Score)
 findBestMove c d b = 
   case getState b of
-    (Draw, _) -> ((99, 99), 0 + d)
-    (Won, s) -> ((99, 99), if c == Engine then 100 - d else -100 + d)
+    (Draw, _) -> ((99, 99), 0)
+    (Won, s) -> ((99, 99), -100 + d)
     (Unfinished, _) -> 
       let possibleMoves = mapMoves b c d $ getMoves b
           minScore = ((99, 99), minBound :: Int)
-      in inverse . foldl maxScore minScore $ possibleMoves
-  where inverse (move, score) = (move, -score)
-        maxScore acc x = if snd x > snd acc then x else acc
+          bestMove = foldl maxScore minScore $ possibleMoves
+      in bestMove
+  where maxScore acc x = if snd x > snd acc then x else acc
 
 mapMoves :: Board -> Color -> Depth -> [Move] -> [(Move, Score)]
-mapMoves b c d moves = zipWith zipScoreMove  (getMoveScores b c d moves) moves
+mapMoves b c d moves = zipWith zipScoreMove (getMoveScores b c d moves) moves
   where zipScoreMove (_, score) move = (move, score)
-        getMoveScores b c d moves = map (findBestMove (toggleColor c) (d + 1) . takeMove b c) moves
+        inverse (move, score) = (move, -score)
+        getMoveScores b c d moves = map (inverse . findBestMove (toggleColor c) (d + 1) . takeMove b c) moves
 
 getMoves :: Board -> [Move]
 getMoves b = concat $ zipWith parseRow b [0..]
@@ -38,7 +40,11 @@ takeMove :: Board -> Color -> Move -> Board
 takeMove b c m = zipWith (updateRow m c) b [0..]
 
 updateRow :: Move -> Color -> [Square] -> Int -> [Square]
-updateRow m c r i = zipWith (\x j -> if (i, j) == m then getSymbol c else x) r [0..]
+updateRow (i', j') c r i = 
+  if i' == i then
+    zipWith (\x j -> if j == j' then getSymbol c else x) r [0..]
+  else
+    r
 
 getSymbol :: Color -> Square
 getSymbol Engine = O
@@ -49,4 +55,4 @@ toggleColor Engine = Player
 toggleColor Player = Engine
 
 parseRow :: [Square] -> Int -> [Move]
-parseRow r i = map (\(Just x) -> x) $ filter (/= Nothing) $ zipWith (\x j -> if x == Empty then Just (i, j) else Nothing) r [0..]
+parseRow r i = map fromJust $ filter (/= Nothing) $ zipWith (\x j -> if x == Empty then Just (i, j) else Nothing) r [0..]

--- a/test/Engine/BoardSpec.hs
+++ b/test/Engine/BoardSpec.hs
@@ -55,6 +55,12 @@ secondDiagMatrix = [
   ["", "O", ""],
   ["O", "", ""]]
 
+colPlayerMatrix :: [[String]]
+colPlayerMatrix = [
+  ["", "", "X"],
+  ["", "", "X"],
+  ["", "", "X"]]
+
 invalidBoard :: Board
 invalidBoard = [
   [Empty, X, Empty],
@@ -79,6 +85,8 @@ mainDiagBoard :: Board
 mainDiagBoard = let (Just b) = fromMatrix colMatrix in b
 secondDiagBoard :: Board
 secondDiagBoard = let (Just b) = fromMatrix colMatrix in b
+colPlayerBoard :: Board
+colPlayerBoard = let (Just b) = fromMatrix colPlayerMatrix in b
 
 spec :: Spec
 spec = do
@@ -108,3 +116,5 @@ spec = do
       (getState mainDiagBoard) `shouldBe` (Won, O)
     it "should be able to see win in secondary diagonal" $ do
       (getState secondDiagBoard) `shouldBe` (Won, O)
+    it "should be able to see a player winning by column" $ do
+      (getState colPlayerBoard) `shouldBe` (Won, X)

--- a/test/Engine/MovesSpec.hs
+++ b/test/Engine/MovesSpec.hs
@@ -4,6 +4,8 @@ import Test.Hspec
 import Engine.Board
 import Engine.Moves
 
+import Data.Maybe
+
 stubMatrix :: [[String]]
 stubMatrix = [
   ["", "X", ""],
@@ -40,3 +42,8 @@ spec = do
   describe "findBestMove" $ do
     it "should find the engine's best move in a given board state" $ do
       (fst $ findBestMove Engine 0 stubBoard) `shouldBe` (0, 0)
+    it "should pick the move that limits player's option the most" $ do
+      (fst $ findBestMove Engine 0 $ fromJust . fromMatrix $ [
+        ["", "", ""],
+        ["", "", ""],
+        ["", "", "X"]]) `shouldBe` (1, 1)


### PR DESCRIPTION
Fixes #16.
The issue was that I was using minimax based scoring in a negamax algorithm, I don't care whether it's the player or the engine on the winning turn since the scores get reversed either way.